### PR TITLE
Warn when persistence helper is missing

### DIFF
--- a/README-V2.md
+++ b/README-V2.md
@@ -75,6 +75,8 @@ name: "Kitchen Heating"        # Display name
 room_temp_key: T_kueche       # Room key for multi-room schedules
 ```
 
+> 💾 **Persistence required for durable changes:** without configuring a persistence helper the card only keeps edits in memory. Reloading the dashboard restores the last schedule that was loaded from Home Assistant.
+
 ### Advanced Configuration
 ```yaml
 type: custom:heizplan-card-v2
@@ -102,7 +104,7 @@ style: |
 
 ### Supported persistence backends
 
-When configuring the optional `persistence` block make sure the target service can store JSON/text payloads:
+When configuring the `persistence` block make sure the target service can store JSON/text payloads:
 
 - `input_text.set_value`
 - `variable.set_variable`

--- a/SETUP-V2.md
+++ b/SETUP-V2.md
@@ -76,6 +76,8 @@ name: "Küche Heizplan"
 room_temp_key: T_kueche
 ```
 
+> 💾 **Important:** without configuring a persistence helper the card only keeps edits in memory. Add a `persistence` block so schedule changes are written somewhere Home Assistant can reload.
+
 ### Advanced Configuration
 ```yaml
 type: custom:heizplan-card-v2

--- a/heizplan-card-v2.ts
+++ b/heizplan-card-v2.ts
@@ -1755,8 +1755,9 @@ export class HeizplanCardV2 extends LitElement {
 
   private async _persistSchedule(): Promise<boolean> {
     if (!this._config?.persistence) {
-      this._debug('No persistence configuration provided; skipping save.');
-      return true;
+      this._errorMessage = 'Schedule not saved: configure a persistence helper in the card options so changes survive reloads.';
+      this._debug('No persistence configuration provided; refusing to persist schedule.');
+      return false;
     }
 
     if (!this._hass) {


### PR DESCRIPTION
## Summary
- surface an error when schedule saves are attempted without a persistence configuration
- document that the card needs a persistence helper to keep changes across reloads in README-V2 and SETUP-V2

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d45015c4a4832c91775684d94a2051