### PR TITLE
Adjust legacy card configuration to drop room key

### DIFF
--- a/README-V2.md
+++ b/README-V2.md
@@ -140,17 +140,21 @@ npm run format
 
 ## 🔄 Migration from V1
 
-**Zero Breaking Changes** - V2 is fully compatible with V1 configurations:
+**Zero Breaking Changes** - V2 accepts every option the legacy card used and adds more when you need them:
 
 ```yaml
-# Simply change the card type:
-type: custom:heizplan-card      # V1
-type: custom:heizplan-card-v2   # V2
-
-# All other settings stay the same!
+# Legacy vanilla card (heizplan-card.js)
+type: custom:heizplan-card
 entity: climate.hk_kuche
 name: "Küche Heizplan"
-# ... rest of config unchanged
+schedule_text_entity: input_text.heizplan_schedule
+
+# Upgrading? Switch the type and optionally add V2-only extras
+type: custom:heizplan-card-v2
+room_temp_key: T_kueche          # Optional multi-room key (V2 only)
+persistence:                      # Optional persistence block (V2 only)
+  domain: input_number
+  service: set_value
 ```
 
 ## 💡 Why LitElement?

--- a/SETUP-V2.md
+++ b/SETUP-V2.md
@@ -168,18 +168,23 @@ interface ScheduleEntry {
 ## Migration from V1
 
 ### Automatic Migration
-V2 uses the same configuration format as V1, so you can simply:
+The legacy vanilla card only expects the basics (`entity`, `name`, `schedule_text_entity`). To migrate:
 
 1. **Install V2** following the setup instructions above
-2. **Change card type** in your dashboard:
+2. **Change the card type** and, if needed, add V2-only options:
    ```yaml
-   # Change this:
+   # Legacy card
    type: custom:heizplan-card
+   schedule_text_entity: input_text.heizplan_schedule
 
-   # To this:
+   # V2 upgrade (optional extras shown)
    type: custom:heizplan-card-v2
+   room_temp_key: T_kueche
+   persistence:
+     domain: input_number
+     service: set_value
    ```
-3. **Keep all other settings** exactly the same
+3. **Keep the original fields** (like `entity` and `name`) unchanged
 
 ### Benefits After Migration
 - **Faster UI updates** when editing schedules

--- a/heizplan-card.js
+++ b/heizplan-card.js
@@ -168,7 +168,6 @@
         min_temp: Number(config.min_temp ?? 5),
         max_temp: Number(config.max_temp ?? 30),
         temp_step: Number(config.temp_step ?? 0.5),
-        room_temp_key: config.room_temp_key || 'T_kueche',
         entity: config.entity,
         schedule_text_entity: config.schedule_text_entity, // single source of truth
       };

--- a/readme.md
+++ b/readme.md
@@ -98,6 +98,22 @@ The input helpers recreate your exact schedule structure:
 
 Add the card to your Lovelace dashboard:
 
+#### Legacy Vanilla Card (`custom:heizplan-card`)
+
+```yaml
+type: custom:heizplan-card
+entity: climate.hk_kuche
+name: "Küche Heizplan"
+schedule_text_entity: input_text.heizplan_schedule
+min_temp: 5
+max_temp: 30
+temp_step: 0.5
+```
+
+> The vanilla JavaScript card stores its schedule in a single `input_text` helper referenced by `schedule_text_entity`. It does not accept `room_temp_key` or persistence blocks.
+
+#### LitElement Card (`custom:heizplan-card-v2`)
+
 ```yaml
 type: custom:heizplan-card-v2
 entity: climate.hk_kuche
@@ -132,7 +148,7 @@ debug: false
 
 ## 📖 Configuration Reference
 
-### Card Configuration Options
+### LitElement Card (`custom:heizplan-card-v2`)
 
 | Option | Type | Default | Required | Description |
 |--------|------|---------|----------|-------------|
@@ -144,6 +160,17 @@ debug: false
 | `room_temp_key` | string | "default_room" | ❌ | Primary room identifier |
 | `persistence` | object | - | ✅ | Storage configuration |
 | `debug` | boolean | false | ❌ | Enable detailed logging |
+
+### Legacy Vanilla Card (`custom:heizplan-card`)
+
+| Option | Type | Default | Required | Description |
+|--------|------|---------|----------|-------------|
+| `entity` | string | - | ✅ | Climate entity controlled by the card |
+| `name` | string | "Heizplan" | ❌ | Card title displayed in header |
+| `min_temp` | number | 5 | ❌ | Minimum temperature limit |
+| `max_temp` | number | 30 | ❌ | Maximum temperature limit |
+| `temp_step` | number | 0.5 | ❌ | Temperature adjustment increment |
+| `schedule_text_entity` | string | - | ✅ | `input_text` helper used to persist the schedule |
 
 ### Persistence Configuration
 
@@ -256,8 +283,9 @@ Service call: input_number.set_value
 **Problem**: "No rooms available in the schedule"
 **Solutions**:
 1. Ensure temperature input helpers exist for your rooms
-2. Verify `room_temp_key` matches your room naming
-3. Check that helpers follow naming convention: `heat_[period]_[room]`
+2. _(V2)_ Verify `room_temp_key` matches your room naming
+3. _(V1)_ Confirm `schedule_text_entity` points to the intended `input_text`
+4. Check that helpers follow naming convention: `heat_[period]_[room]`
 
 #### Temperature changes reset after reload
 


### PR DESCRIPTION
## Summary
- remove the unused `room_temp_key` assignment from the legacy `heizplan-card.js`
- document the minimal configuration expected by the vanilla card and flag V2-only options
- update migration guides to explain the difference between legacy and LitElement cards

## Testing
- not run (Home Assistant environment unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d8ec246344832ca325d5f5d3bdd17f