### PR TITLE
Localize day headers to German

### DIFF
--- a/heizplan-card-v2.ts
+++ b/heizplan-card-v2.ts
@@ -57,6 +57,16 @@ interface PersistenceConfig {
   data?: Record<string, unknown>;
 }
 
+const DAY_LABELS: Record<string, { long: string; short: string }> = {
+  monday: { long: 'Montag', short: 'Mo' },
+  tuesday: { long: 'Dienstag', short: 'Di' },
+  wednesday: { long: 'Mittwoch', short: 'Mi' },
+  thursday: { long: 'Donnerstag', short: 'Do' },
+  friday: { long: 'Freitag', short: 'Fr' },
+  saturday: { long: 'Samstag', short: 'Sa' },
+  sunday: { long: 'Sonntag', short: 'So' }
+};
+
 @customElement('heizplan-card-v2')
 export class HeizplanCardV2 extends LitElement {
   private _hass?: HomeAssistant;
@@ -734,16 +744,11 @@ export class HeizplanCardV2 extends LitElement {
   }
 
   private _formatDayLabel(day: string, short = false): string {
-    const date = new Date();
-    const days = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
-    const index = days.indexOf(day.toLowerCase());
+    const key = day.toLowerCase();
+    const labels = DAY_LABELS[key];
 
-    if (index !== -1) {
-      const baseDate = new Date(date.getFullYear(), date.getMonth(), date.getDate() - date.getDay() + index);
-      const formatter = new Intl.DateTimeFormat(this._hass?.locale?.language ?? undefined, {
-        weekday: short ? 'short' : 'long'
-      });
-      return formatter.format(baseDate);
+    if (labels) {
+      return short ? labels.short : labels.long;
     }
 
     const normalized = day.charAt(0).toUpperCase() + day.slice(1);

--- a/heizplan-card.js
+++ b/heizplan-card.js
@@ -370,7 +370,16 @@
   `;
 
   const DAYS = ['monday','tuesday','wednesday','thursday','friday','saturday','sunday'];
-  const DAY_SHORT = { monday: 'Mo', tuesday: 'Di', wednesday: 'Mi', thursday: 'Do', friday: 'Fr', saturday: 'Sa', sunday: 'So' };
+  const DAY_NAMES = {
+    monday:   { long: 'Montag',    short: 'Mo' },
+    tuesday:  { long: 'Dienstag',  short: 'Di' },
+    wednesday:{ long: 'Mittwoch',  short: 'Mi' },
+    thursday: { long: 'Donnerstag',short: 'Do' },
+    friday:   { long: 'Freitag',   short: 'Fr' },
+    saturday: { long: 'Samstag',   short: 'Sa' },
+    sunday:   { long: 'Sonntag',   short: 'So' }
+  };
+  const DAY_SHORT = Object.fromEntries(Object.entries(DAY_NAMES).map(([key, value]) => [key, value.short]));
 
   class HeizplanCard extends HTMLElement {
     // ----- Lifecycle -----
@@ -573,7 +582,8 @@
 
     _renderSingleDay(){
       const day = this._currentDay;
-      this.$.dayHeader.textContent = day[0].toUpperCase() + day.slice(1);
+      const label = DAY_NAMES[day]?.long ?? day[0].toUpperCase() + day.slice(1);
+      this.$.dayHeader.textContent = label;
       this.$.timeline.dataset.day = day;
       this._fillTimeline(this.$.timeline, this._schedule[day] || [], day);
     }


### PR DESCRIPTION
## Summary
- add a reusable German day label mapping for both TypeScript and JavaScript implementations
- update the single-day view header to display localized German day names

## Testing
- `npm run build` *(fails: Could not resolve entry module "heizplan-card-v3.ts")*

------
https://chatgpt.com/codex/tasks/task_e_68db832ef6d0832cbe5b0cf3d80cfab6