### PR TITLE
Auto apply schedule temperature changes

### DIFF
--- a/heizplan-card.js
+++ b/heizplan-card.js
@@ -481,8 +481,12 @@
           }
         }
         if (scheduledTemp !== null && !Number.isNaN(scheduledTemp)) {
-          if (prevScheduled === null || Math.abs(scheduledTemp - prevScheduled) > tolerance) {
+          const scheduledChanged = prevScheduled !== null && Math.abs(scheduledTemp - prevScheduled) > tolerance;
+          if (prevScheduled === null || scheduledChanged) {
             this._clearManualOverride();
+          }
+          if (scheduledChanged && !this._manualOverrideActive && this._pendingScheduledTemp === null) {
+            this._setTemp(scheduledTemp, { fromSchedule: true });
           }
           const entityTemp = Number(entity.attributes.temperature);
           if (!Number.isNaN(entityTemp)) {


### PR DESCRIPTION
## Summary
- trigger the thermostat when the active schedule temperature changes without a manual override
- reuse the existing tolerance and pending command checks to avoid duplicate service calls

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd98c75184832c8cb0bf7e28f729cc